### PR TITLE
feat: add delivery status tracking

### DIFF
--- a/src/DTO/Delivery.php
+++ b/src/DTO/Delivery.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace SergeevPasha\Pecom\DTO;
 
-use SergeevPasha\Pecom\DTO\Service;
 use Spatie\DataTransferObject\DataTransferObject;
 use SergeevPasha\Pecom\DTO\Collection\CargoCollection;
 

--- a/src/DTO/PecomTrack.php
+++ b/src/DTO/PecomTrack.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SergeevPasha\Pecom\DTO;
+
+use Carbon\Carbon;
+use Spatie\DataTransferObject\DataTransferObject;
+
+class PecomTrack extends DataTransferObject
+{
+    /**
+     * @var string|null
+     */
+    public ?string $status;
+
+    /**
+     * @var string
+     */
+    public string $link;
+
+    /**
+     * @var \Carbon\Carbon|null
+     */
+    public ?Carbon $startDate;
+
+    /**
+     * @var \Carbon\Carbon|null
+     */
+    public ?Carbon $receiveDate;
+
+    /**
+     * From Array.
+     *
+     * @param array $data
+     *
+     * @return self
+     * @throws \Spatie\DataTransferObject\Exceptions\UnknownProperties
+     */
+    public static function fromArray(array $data): self
+    {
+        $cargoInfo = $data['cargos'][0]['info'] ?? [];
+
+        $status = $cargoInfo['cargoStatus'] ?? null;
+        $orderId = $data['cargos'][0]['cargo']['code'] ?? '';
+        $link = $orderId ? 'https://pecom.ru/services-are/order-status/?code=' . $orderId : '';
+
+
+        $startDate = isset($cargoInfo['takeOnStockDateTime'])
+            ? Carbon::parse($cargoInfo['takeOnStockDateTime'])
+            : null;
+
+        $receiveDate = isset($cargoInfo['receivedByClientDateTime'])
+            ? Carbon::parse($cargoInfo['receivedByClientDateTime'])
+            : (isset($cargoInfo['giveOutDateTime'])
+                ? Carbon::parse($cargoInfo['giveOutDateTime'])
+                : null);
+
+        return new self([
+            'status'            => $status,
+            'link'              => $link,
+            'startDate'         => $startDate,
+            'receiveDate'       => $receiveDate,
+        ]);
+    }
+}

--- a/src/Http/Controllers/PecomController.php
+++ b/src/Http/Controllers/PecomController.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace SergeevPasha\Pecom\Http\Controllers;
 
 use Exception;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Http\JsonResponse;
 use SergeevPasha\Pecom\DTO\Delivery;
 use Illuminate\Support\Facades\Validator;
+use SergeevPasha\Pecom\Http\Requests\PecomDeliveryStatusRequest;
 use SergeevPasha\Pecom\Libraries\PecomClient;
 use Illuminate\Validation\ValidationException;
 use SergeevPasha\Pecom\Http\Requests\PecomQueryCityRequest;
@@ -98,5 +100,23 @@ class PecomController
         $data = $this->client->getPrice(Delivery::fromArray($request->all()));
         $this->validateResponse($data);
         return response()->json($data);
+    }
+
+    /**
+     * Get cargo status by cargo codes.
+     *
+     * @param PecomDeliveryStatusRequest $request
+     *
+     * @return JsonResponse
+     * @throws GuzzleException
+     * @throws Exception
+     * @api
+     *
+     */
+    public function getCargoStatus(PecomDeliveryStatusRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+        $result = $this->client->getOrderHistory($data['cargo_code']);
+        return response()->json($result[0]['statuses']);
     }
 }

--- a/src/Http/Requests/PecomDeliveryStatusRequest.php
+++ b/src/Http/Requests/PecomDeliveryStatusRequest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace SergeevPasha\Pecom\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PecomDeliveryStatusRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'cargo_code' => ['required', 'string'],
+        ];
+    }
+}

--- a/src/Libraries/PecomClient.php
+++ b/src/Libraries/PecomClient.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace SergeevPasha\Pecom\Libraries;
 
 use Exception;
+use GuzzleHttp\Exception\GuzzleException;
 use SergeevPasha\Pecom\DTO\Delivery;
 use SergeevPasha\Pecom\DTO\Collection\CargoCollection;
+use SergeevPasha\Pecom\DTO\PecomTrack;
+use Spatie\DataTransferObject\Exceptions\UnknownProperties;
 
 class PecomClient
 {
@@ -123,6 +126,50 @@ class PecomClient
         }
     }
 
+    /**
+     * Get basic cargo status information by cargo codes.
+     *
+     * @param string $cargoCode
+     * @return PecomTrack
+     * @throws GuzzleException
+     * @throws UnknownProperties
+     */
+    public function findByTrackNumber(string $cargoCode): PecomTrack
+    {
+        $data = $this->request(
+            'https://kabinet.pecom.ru/api/v1/cargos/basicstatus',
+            [
+                'cargoCodes' => [$cargoCode],
+            ]
+        );
+        return PecomTrack::fromArray($data);
+    }
+
+    /**
+     * Get Orders History.
+     *
+     * @param array $cargoCodes
+     * @return array
+     * @throws GuzzleException
+     */
+    public function getOrdersHistory(array $cargoCodes): array
+    {
+        return $this->request('https://kabinet.pecom.ru/api/v1/cargos/statusfullhistory', [
+            'cargoCodes' => $cargoCodes
+        ]);
+    }
+
+    /**
+     * Get Order History.
+     *
+     * @param string $cargoCode
+     * @return array
+     * @throws GuzzleException
+     */
+    public function getOrderHistory(string $cargoCode): array
+    {
+        return $this->getOrdersHistory([$cargoCode]);
+    }
     /**
      * Find all available city terminals
      *

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -9,3 +9,5 @@ Route::get('/cities/{city}/terminals', [PecomController::class, 'getCityTerminal
     ->name('pecom.cities.terminals');
 Route::post('/calculate', [PecomController::class, 'calculateDeliveryPrice'])
     ->name('pecom.calculate');
+Route::get('/history', [PecomController::class, 'getCargoStatus'])
+    ->name('pecom.history');


### PR DESCRIPTION
This pull request adds new functionality for retrieving cargo status and history from the Pecom API. The main changes include introducing a new DTO for tracking cargo status, adding request validation for cargo code queries, updating the client library to support new endpoints, and exposing a new controller method and route for accessing cargo history.

### New cargo tracking and history features

* Added `PecomTrack` DTO to represent cargo status, link, and relevant dates, with a static `fromArray` constructor for easy instantiation from API responses.
* Updated `PecomClient` with methods to fetch cargo status (`findByTrackNumber`) and full history (`getOrdersHistory`, `getOrderHistory`), integrating with Pecom API endpoints.

### Request validation and controller updates

* Introduced `PecomDeliveryStatusRequest` for validating incoming requests for cargo status, ensuring the `cargo_code` field is present and a string.
* Added `getCargoStatus` method to `PecomController` to handle cargo status requests, using the new client and request classes.

### Routing

* Registered new `/history` route mapped to the `getCargoStatus` controller method for accessing cargo status via HTTP GET.